### PR TITLE
create new topic newest version 

### DIFF
--- a/SetUpKafka.md
+++ b/SetUpKafka.md
@@ -91,7 +91,7 @@ kafka-server-start.bat ..\..\config\server.properties
 ## How to create a topic ?
 
 ```
-kafka-topics.bat --create --topic test-topic -zookeeper localhost:2181 --replication-factor 1 --partitions 4
+kafka-topics.bat --create --topic test-topic --bootstrap-server localhost:9092 --replication-factor 1 --partitions 4
 ```
 
 ## How to instantiate a Console Producer?


### PR DESCRIPTION
it is deprecated this command to create new topic in versions +2.2 
old: kafka-topics.bat --create --topic test-topic -zookeeper localhost:2181 --replication-factor 1 --partitions 4
new: >kafka-topics.bat --create --topic test-topic --bootstrap-server localhost:9092 --replication-factor 1 --partitions 4